### PR TITLE
Remove VireoSDK Custom URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,7 @@
 
       // Put custom repo URL's in this object, keyed by repo name.
       var repoUrls = {
-        "nilrt": "http://forums.ni.com/t5/NI-Linux-Real-Time/ct-p/7013",
-        "VireoSDK": "https://ni.github.io/VireoSDK/"
+        "nilrt": "http://forums.ni.com/t5/NI-Linux-Real-Time/ct-p/7013"
       };
 
       function repoUrl(repo) {

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <div id="statistics" class="grid-1 alpha header">
           <h1>Statistics</h1>
           <p>
-            <a href="https://github.com/ni/repositories"><span id="num-repos"><img src="assets/spinner.gif" /></span> public repos</a>
+            <a href="https://github.com/ni/"><span id="num-repos"><img src="assets/spinner.gif" /></span> public repos</a>
             <br>
             <a href="https://github.com/ni?tab=members"><span id="num-members"><img src="assets/spinner.gif" /></span> members</a>
           </p>
@@ -48,7 +48,7 @@
         </div>
 
         <div id="recently-updated" class="grid-2 omega header">
-          <h1>Recently updated <a href="https://github.com/ni/repositories">View All on GitHub</a></h1>
+          <h1>Recently updated <a href="https://github.com/ni/">View All on GitHub</a></h1>
           <ol id="recently-updated-repos"></ol>
         </div>
       </div>


### PR DESCRIPTION
- Removes the custom VireoSDK URL as VireoSDK no longer publishes its own GitHub Pages
- Fixes the view all repositories link